### PR TITLE
Add syntax header to each proto file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,10 @@ EXTRA_DIST += \
 
 TESTS_ENVIRONMENT = NMSG_MSGMOD_DIR=$(top_builddir)/.libs
 
+EXTRA_DIST += tests/errors.h
+EXTRA_DIST += tests/generic-tests/dedupe.nmsg
+EXTRA_DIST += tests/generic-tests/newdomain.nmsg
+
 TESTS += tests/test-parse
 check_PROGRAMS += tests/test-parse
 tests_test_parse_LDADD = $(libnmsg_LIBS)

--- a/delay.proto
+++ b/delay.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 message Delay {

--- a/dnsdedupe.proto
+++ b/dnsdedupe.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 enum DnsDedupeType {

--- a/dnsnx.proto
+++ b/dnsnx.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 message DnsNX {

--- a/newdomain.proto
+++ b/newdomain.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 import "dnsdedupe.proto";

--- a/qr.proto
+++ b/qr.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 enum QRType {

--- a/reputation.proto
+++ b/reputation.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.sie;
 
 enum ReputationType {


### PR DESCRIPTION
See related commit in the base nmsg project: https://github.com/farsightsec/nmsg/commit/a3b4803ba2cee0b8493308820a979ccdbfd28f34

Lack of the syntax header creates issues with protobuf tools, eg. the golang pbparser library: https://github.com/tallstoat/pbparser